### PR TITLE
Upgrade boomi connector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,13 @@ dependencies {
         exclude group: 'com.boomi.connsdk', module: 'connector-sdk-api'
         exclude group: 'com.boomi.util', module: 'boomi-util'
     }
-    testImplementation "org.junit.jupiter:junit-jupiter:5.5.2"
+    testImplementation "org.junit.jupiter:junit-jupiter:5.6.2"
     testImplementation "io.pravega:pravega-standalone:${pravegaVersion}"
     testImplementation "com.boomi.connsdk:connector-sdk-test-util:${boomiConnectorVersion}"
     testImplementation "org.slf4j:slf4j-api:1.7.9"
     testImplementation "ch.qos.logback:logback-core:1.2.3"
     testRuntimeOnly "ch.qos.logback:logback-classic:1.2.3"
+    testRuntimeOnly "com.google.guava:guava:31.1-jre"
 }
 
 distributions {
@@ -50,6 +51,11 @@ distributions {
                 from configurations.runtimeClasspath
                 from jar
             }
+
+            // Exclude the jars that are available in the atom or those that are required for testing
+            exclude("bcprov-ext-jdk15on-1.70.jar")
+            exclude("guava-*.jar")
+            exclude("slf4j*.jar")
             into '/'
         }
     }
@@ -74,4 +80,8 @@ licenseReport {
 test {
     useJUnitPlatform()
     systemProperties 'singlenode.configurationFile': project.file('src/test/resources/standalone-config.properties')
+
+    // Adjust heap size for running local pravega emulator during testing
+    minHeapSize = "512m" // initial heap size
+    maxHeapSize = "16384m" // maximum heap size
 }

--- a/doc/Pravega Connector Developer's Guide.md
+++ b/doc/Pravega Connector Developer's Guide.md
@@ -1,0 +1,62 @@
+# boomi-pravega-connector
+A Pravega connector for the [Boomi Atomsphere](https://boomi.com/platform/integration/applications/)
+
+## Pre-requisites
+  - **Accounts**
+    - A boomi platform account
+  - **Tools**
+    - Java 11
+    - An SDP installation
+    - kubectl client configured to access the SDP cluster
+    - A docker installation for running boomi Atoms
+
+
+## Steps to configure Boomi Platform
+1. Create a boomi platform account and save the credentials
+2. Create a boomi environment on your boomi account. This environment will be used to test processes using the connector.
+3. Create a local boomi Atom using the official boomi Atom docker image. Use the following command to create a boomi Atom running inside docker
+   - ```sh 
+     docker run --privileged -p 9090:9090 -h localhost -e BOOMI_USERNAME=<your-boomi-account-username> -e BOOMI_PASSWORD=<your-boomi-account-password> -e BOOMI_ACCOUNTID=<your-boomi-accountID> -e BOOMI_ATOMNAME="Pravega Boomi Atom" -e ATOM_LOCALHOSTID="Pravega Boomi Atom ID" -v /opt/boomi:/run:Z --rm -it boomi/atom:3.2.12
+     ```
+   - This will run a local boomi Atom docker container on your machine
+4. On the boomi environments page, you should see a running boomi Atom named 'Pravega Boomi Atom' in the list of 'Unattached Atoms'. Click on the atom and attach it to the environment created earlier.
+
+***Note:** Since SDP uses self-signed certificates across the installation, your local boomi Atom may not be able to connect to SDP Pravega. Either use valid a set of certificates or create a custom boomi Atom docker image with the mounted self-signed certificates. Refer to the [documentation](#create-a-custom-docker-image) on steps to generate a docker image.*
+
+## Steps to create and upload a custom boomi connector to boomi platform
+- Please refer to the section 'Create a Custom Connector' under the [boomi connector](../README.md)
+
+
+## Steps to get details from SDP cluster to connect with boomi Platform
+- Create a project named `boomi`
+- Fetch SDP Pravega Endpoint
+  - ```shell
+    kubectl get ingress -n nautilus-pravega pravega-controller
+    ```
+  - Output of the above command should give you a URL pointing to the pravega-controller
+- Fetch SDP Pravega Keycloak OIDC (Keycloak JSON)
+  - ```shell
+    kubectl get secrets -n boomi boomi-ext-pravega -o jsonpath='{.data.keycloak\.json}' | base64 -d
+    ```
+  - The output of the above command to be used as the value for `Keycloak OIDC` in the boomi connector
+
+## Steps to create process on boomi platform
+- Please refer to the [Getting Started Guide](Pravega%20Connector%20Getting%20Started%20Guide.md) for creating process on Boomi with boomi-pravega-connectors
+
+## Create a custom docker image with self-signed certificates
+- Obtain the certificates you want to add to the Linux/JVM trust store
+- Place the certificates in the directory `/usr/share/ca-certificates`
+- Run `dpkg-reconfigure ca-certificates` (This may require you to have admin privileges)
+- Select the certificates you want to import
+- Once finished, the command will update the system-wide ca-bundle located at `/etc/ssl/certs/ca-bundle.crt`
+- Copy the ca-bundle to the same directory as your Dockerfile
+- Add the ca-bundle to your Dockerfile and move it to `/etc/ssl/certs/ca-bundle.crt`
+  - ```shell
+    COPY ca-bundle.crt .
+    RUN mv ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
+    ```
+- To update the JVM trust store, add the following command to your Dockerfile, this will update the java keystore in your docker image with the certificates provided
+  - ```shell
+    RUN keytool -importcert -keystore /usr/java/latest/lib/security/cacerts -storepass changeit -noprompt -trustcacerts -file /etc/ssl/certs/ca-bundle.crt
+    ```
+- Build the docker image!

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 releaseVersion=2.1.2
 
-pravegaVersion=0.8.0
-pravegaKeycloakVersion=0.8.0
-jsonPathVersion=2.4.0
+pravegaVersion=0.12.0
+pravegaKeycloakVersion=0.12.0
+jsonPathVersion=2.7.0
 boomiUtilVersion=2.3.8
 boomiCommonSdkVersion=1.1.9
 boomiConnectorVersion=2.8.0

--- a/src/test/java/io/pravega/connector/boomi/PravegaBrowserTest.java
+++ b/src/test/java/io/pravega/connector/boomi/PravegaBrowserTest.java
@@ -144,7 +144,6 @@ public class PravegaBrowserTest {
         1. Must have access to an SDP cluster
         2. The expected scope must be created on the cluster
         3. The Pravega endpoint, scope, stream and keyclaok.json file path must be set in a properties file
-        4. Must have a valid Keycloak JWT in your home directory
      */
     @Test
     public void testTestNautilusConnector() throws Exception {

--- a/src/test/java/io/pravega/connector/boomi/PravegaOperationTest.java
+++ b/src/test/java/io/pravega/connector/boomi/PravegaOperationTest.java
@@ -205,8 +205,8 @@ public class PravegaOperationTest {
     }
 
     @Test
-    public void test2MBWriteOperation() {
-        String json = TestUtils.generate2MBmessage();
+    public void test1MBWriteOperation() {
+        String json = TestUtils.generate1MBmessage();
         PravegaConnector connector = new PravegaConnector();
         ConnectorTester tester = new ConnectorTester(connector);
 

--- a/src/test/java/io/pravega/connector/boomi/TestUtils.java
+++ b/src/test/java/io/pravega/connector/boomi/TestUtils.java
@@ -114,8 +114,8 @@ final class TestUtils {
         return "{\"name\":\"foo\",\"message\":\"" + randomMessage + "\"}";
     }
 
-    static String generate2MBmessage() {
-        char[] chars = new char[2000000];
+    static String generate1MBmessage() {
+        char[] chars = new char[1000000];
         Arrays.fill(chars, 'a');
         String randomMessage = new String(chars);
         return "{\"name\":\"foo\",\"message\":\"" + randomMessage + "\"}";

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,4 +1,4 @@
-sdp_endpoint = "tcp://127.0.0.1:9090"
+sdp_endpoint = tcp://127.0.0.1:9090
 sdp_auth_type = Keycloak
 local_pravega_auth_type = None
 interval = 10


### PR DESCRIPTION
## Updates
- Update pravega and keycloak clients to version 0.12.0
- Fix junit tests where the default event write size has been changed to 1MB
- Add JVM heap size argument to gradle build for local testing (This is required as one of tests depends on the latency at which events can be read from pravega. Higher memory accounts for lower latency and hence passing tests)
- Exclude jars that are already available in a boomi atom or that are required for testing from distZip to reduce distribution size
- Add developer's doc for steps to test boomi connector with SDP

## Integrations Tests
- A locally running Boomi Atom ![running atom](https://user-images.githubusercontent.com/39532976/203876452-4373680c-658a-4a3b-a555-855fac31c4d3.png)
- Pravega Reader Process in Boomi Atomsphere ![running_pravega_reader_process](https://user-images.githubusercontent.com/39532976/203876271-7c8fb05f-51ab-4ef1-96e4-314a13df2a95.png)
- Pravega Writer Process in Boomi Atomsphere ![running_pravega_writer_process](https://user-images.githubusercontent.com/39532976/203876309-ce550970-5d76-4d73-af51-8a0f101cf70a.png)
- Pravega Stream in SDP created by the Boomi Writer Process ![sdp_pravega_stream_reader_data](https://user-images.githubusercontent.com/39532976/203876334-acda6dea-7322-40ae-b4c1-0682ae48f314.png)

## Packaging
- Distribution zip ![dist](https://user-images.githubusercontent.com/39532976/203876396-e06ff5f5-990e-4b62-84bc-59ecf128ce88.png)

## Unit tests
- Running Junits ![test](https://user-images.githubusercontent.com/39532976/203876422-1d60ef39-ba02-4626-b67b-ea2964073e47.png)
